### PR TITLE
Update for SMAPI 2.8 and Stardew Valley 1.3.31

### DIFF
--- a/BetterRanching/BetterRanching.csproj
+++ b/BetterRanching/BetterRanching.csproj
@@ -35,12 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/BetterRanching/BetterRanching.csproj
+++ b/BetterRanching/BetterRanching.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,9 +11,6 @@
     <AssemblyName>BetterRanching</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,6 +30,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180428" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -55,10 +55,6 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
@@ -69,12 +65,5 @@
     <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
     <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
-  </Target>
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180428\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/BetterRanching/BetterRanching.csproj
+++ b/BetterRanching/BetterRanching.csproj
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0-beta-20180428" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/BetterRanching/BetterRanching.csproj
+++ b/BetterRanching/BetterRanching.csproj
@@ -46,7 +46,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="config.json" />
     <None Include="manifest.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/BetterRanching/BetterRanching.csproj
+++ b/BetterRanching/BetterRanching.csproj
@@ -57,13 +57,4 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="AfterBuild">
-    <PropertyGroup>
-      <ModPath>$(GamePath)\Mods\$(TargetName)</ModPath>
-    </PropertyGroup>
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll" DestinationFolder="$(ModPath)" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
-    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
-  </Target>
 </Project>

--- a/BetterRanching/GameConstants.cs
+++ b/BetterRanching/GameConstants.cs
@@ -8,10 +8,4 @@
             public const string Shears = "Shears";
         }
     }
-
-    public enum RanchType
-    {
-        Milking,
-        Shearing
-    }
 }

--- a/BetterRanching/GameConstants.cs
+++ b/BetterRanching/GameConstants.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BetterRanching
+﻿namespace BetterRanching
 {
     public static class GameConstants
     {

--- a/BetterRanching/GameExtensions.cs
+++ b/BetterRanching/GameExtensions.cs
@@ -1,11 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using StardewValley;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BetterRanching
 {

--- a/BetterRanching/Properties/AssemblyInfo.cs
+++ b/BetterRanching/Properties/AssemblyInfo.cs
@@ -3,5 +3,5 @@
 [assembly: AssemblyTitle("BetterRanching")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCompany("Urbanyeti")]
-[assembly: AssemblyVersion("1.7.0")]
-[assembly: AssemblyFileVersion("1.7.0")]
+[assembly: AssemblyVersion("1.7.1")]
+[assembly: AssemblyFileVersion("1.7.1")]

--- a/BetterRanching/Properties/AssemblyInfo.cs
+++ b/BetterRanching/Properties/AssemblyInfo.cs
@@ -1,36 +1,7 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("BetterRanching")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Urbanyeti")]
-[assembly: AssemblyProduct("BetterRanching")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("40a8f610-b967-49b9-8445-162c034fc047")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.*")]
-[assembly: AssemblyFileVersion("1.6.0")]
+[assembly: AssemblyVersion("1.7.0")]
+[assembly: AssemblyFileVersion("1.7.0")]

--- a/BetterRanching/config.json
+++ b/BetterRanching/config.json
@@ -1,6 +1,0 @@
-﻿{
-  "PreventFailedHarvesting": true,
-  "PreventHarvestRepeating" : true,
-  "DisplayHearts": false,
-  "DisplayProduce": false
-}

--- a/BetterRanching/manifest.json
+++ b/BetterRanching/manifest.json
@@ -1,13 +1,10 @@
 ﻿{
   "Name": "Better Ranching",
   "Author": "Urbanyeti",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 7,
-    "PatchVersion": 0,
-    "Build": ""
-  },
+  "Version": "1.7.0",
   "Description": "Prevents failed milk/shear attempts and displays when animals can be milked/sheared and petted.",
   "UniqueID": "BetterRanching",
-  "EntryDll": "BetterRanching.dll"
+  "EntryDll": "BetterRanching.dll",
+  "MinimumApiVersion": "2.7.0",
+  "UpdateKeys": [ "Nexus:859" ]
 }

--- a/BetterRanching/manifest.json
+++ b/BetterRanching/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
   "Name": "Better Ranching",
   "Author": "Urbanyeti",
-  "Version": "1.7.0",
+  "Version": "1.7.1",
   "Description": "Prevents failed milk/shear attempts and displays when animals can be milked/sheared and petted.",
   "UniqueID": "BetterRanching",
   "EntryDll": "BetterRanching.dll",
-  "MinimumApiVersion": "2.7.0",
+  "MinimumApiVersion": "2.8-beta",
   "UpdateKeys": [ "Nexus:859" ]
 }

--- a/BetterRanching/packages.config
+++ b/BetterRanching/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180428" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
This pull request...

* Updates the code for SMAPI 2.8 and Stardew Valley 1.3.31.
* Adds update keys to the `manifest.json` and standardises the version format.
* Includes some minor cleanup (to remove unused types and references, remove an unneeded deploy task which is handled automatically now, etc).

If the changes look fine, can you deploy [BetterRanching 1.7.1.zip](https://github.com/urbanyeti/stardew-better-ranching/files/2523993/BetterRanching.1.7.1.zip) to [the Nexus page](https://www.nexusmods.com/stardewvalley/mods/859)? (This build won't work in 1.3.28, so I suggest keeping the previous file too for players who aren't using the beta.)