### PR TITLE
Don't show bubbles during events (cutscenes)

### DIFF
--- a/BetterRanching/BetterRanching.cs
+++ b/BetterRanching/BetterRanching.cs
@@ -148,7 +148,7 @@ namespace BetterRanching
 		/// <param name="e">The event data.</param>
 		private void OnRenderingHud(object sender, RenderingHudEventArgs e)
 		{
-			if (!Context.IsWorldReady || !Game1.currentLocation.IsFarm)
+			if (!Context.IsWorldReady || !Game1.currentLocation.IsFarm || Game1.eventUp)
 			{
 				return;
 			}


### PR DESCRIPTION
BR skips showing bubbles when the world isn't ready or when the player isn't at the farm. However, SDV seems to hide pets during events, which results in a bubble over an invisible pet on farmhouse exit cutscene.

SMAPI doesn't have a Context precise enough to target this, as using IsPlayerFree hides the bubble when in menu, so I used Game1.eventUp to skip bubble drawing during events (cutscenes).

This change is made for both animal and pet bubbles, on the theory that the bubbles aren't actionable during an event, so no need to draw them.