### PR TITLE
Switch to using a new 1.6 method to allow for better compatibility with other mods

### DIFF
--- a/BetterRanching/BetterRanching.cs
+++ b/BetterRanching/BetterRanching.cs
@@ -201,7 +201,7 @@ namespace BetterRanching
 		{
 			if (!Context.IsWorldReady || Game1.eventUp) return;
 
-			var farmAnimalList = Game1.currentLocation.animals.Values;
+			var farmAnimalList = Game1.currentLocation.getAllFarmAnimals();
 
 			foreach (var farmAnimal in farmAnimalList)
 				Api.DrawItemBubble(Game1.spriteBatch, farmAnimal, AnimalBeingRanched == farmAnimal);


### PR DESCRIPTION
I have a mod that allows content pack creators to spawn farm animals using content packs, and I have `GameLocation.getAllFarmAnimals()` patched to exclude animals spawned via a content pack.

A mod author using that functionality is getting bug reports that Better Ranching is displaying the pet icon over them. This PR would fix that automatically.

Feel free to let me know if you have any questions, but hopefully you like the change!