### PR TITLE
Improve compatibility with mods that override harvest tool or mods that add new custom tools

### DIFF
--- a/BetterRanching/BetterRanching.cs
+++ b/BetterRanching/BetterRanching.cs
@@ -8,6 +8,7 @@ using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Characters;
 using StardewValley.GameData.FarmAnimals;
+using StardewValley.Tools;
 
 namespace BetterRanching
 {
@@ -139,11 +140,11 @@ namespace BetterRanching
 					toolRect);
 
 			OverrideRanching(Game1.currentLocation, (int)who.GetToolLocation().X, (int)who.GetToolLocation().Y, who,
-				e.Button, who.CurrentTool?.Name);
+				e.Button, who.CurrentTool);
 		}
 
 		private void OverrideRanching(GameLocation currentLocation, int x, int y, Farmer who, SButton button,
-			string toolName)
+			Tool tool)
 		{
 			AnimalBeingRanched = null;
 			FarmAnimal animal = null;
@@ -151,16 +152,16 @@ namespace BetterRanching
 			var ranchActionPresent = string.Empty;
 			var ranchProduct = string.Empty;
 
-			if (toolName == null) return;
+			if (tool == null) return;
 
-			switch (toolName)
+			switch (tool)
 			{
-				case GameConstants.Tools.MilkPail:
+				case MilkPail:
 					ranchAction = Helper.Translation.Get("action.unable.milk");
 					ranchActionPresent = Helper.Translation.Get("action.out_of_range.milk");
 					ranchProduct = Helper.Translation.Get("product.milk");
 					break;
-				case GameConstants.Tools.Shears:
+				case Shears:
 					ranchAction = Helper.Translation.Get("action.unable.shear");
 					ranchActionPresent = Helper.Translation.Get("action.out_of_range.shear");
 					ranchProduct = Helper.Translation.Get("product.wool");
@@ -178,14 +179,14 @@ namespace BetterRanching
 
 			FarmAnimalData animalData = animal.GetAnimalData();
 
-			if (animal.CanBeRanched(toolName))
+			if (animal.CanBeRanched(tool))
 			{
 				if (who.couldInventoryAcceptThisItem(animal.currentProduce.Value, (!animal.hasEatenAnimalCracker.Value) ? 1 : 2, animal.produceQuality.Value))
 					AnimalBeingRanched = animal;
 				else
 					Helper.Input.OverwriteState(button, Helper.Translation.Get("notification.inventory_full"));
 			}
-			else if (animal.isBaby() && animalData.HarvestTool == toolName)
+			else if (animal.isBaby() && animal.CanGetProduceWithTool(tool))
 			{
 				Helper.Input.OverwriteState(button);
 				DelayedAction.showDialogueAfterDelay(

--- a/BetterRanching/BetterRanchingApi.cs
+++ b/BetterRanching/BetterRanchingApi.cs
@@ -5,6 +5,7 @@ using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Characters;
 using StardewValley.GameData.Pets;
+using StardewValley.GameData.FarmAnimals;
 using StardewValley.ItemTypeDefinitions;
 
 namespace BetterRanching
@@ -65,8 +66,7 @@ namespace BetterRanching
 				animal.GetSpriteWidthForPositioning() * (animal.buildingTypeILiveIn.Contains("Coop") && animal.isAdult() ? -1 : 1),
 				animal.buildingTypeILiveIn.Contains("Coop") && animal.isAdult(),
 				produceId,
-				() => !ranchingInProgress && (animal.CanBeRanched(GameConstants.Tools.MilkPail) ||
-												animal.CanBeRanched(GameConstants.Tools.Shears)),
+				() => !ranchingInProgress && animal.currentProduce.Value != null && animal.isAdult() && animal.GetHarvestType() == FarmAnimalHarvestType.HarvestWithTool,
 				() => !animal.wasPet.Value,
 				true,
 				false,

--- a/BetterRanching/GameExtensions.cs
+++ b/BetterRanching/GameExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework.Input;
 using StardewModdingAPI;
 using StardewValley;
 using StardewValley.TerrainFeatures;
+using StardewValley.Tools;
 using xTile.Dimensions;
 using xTile.Tiles;
 
@@ -12,10 +13,10 @@ namespace BetterRanching
 {
 	public static class GameExtensions
 	{
-		public static bool CanBeRanched(this FarmAnimal animal, string toolName)
+		public static bool CanBeRanched(this FarmAnimal animal, Tool tool)
 		{
 			return animal.currentProduce.Value != null && animal.isAdult() &&
-			       animal.GetAnimalData().HarvestTool == toolName;
+			       animal.CanGetProduceWithTool(tool);
 		}
 
 		public static void OverwriteState(this IInputHelper input, SButton button, string message = null)


### PR DESCRIPTION
This change simply uses the built-in function `FarmAnimal.CanGetProduceWithTool` instead of comparing the harvest method directly.

This improves compatibility with [Extra Animal Config](https://www.nexusmods.com/stardewvalley/mods/25328), which allows overriding harvest method on a per-produce basis.